### PR TITLE
Bump Hawking Parser version to 0.1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ version = '1.0-SNAPSHOT'
 def koin_version = '3.3.3'
 def jdbi_version = '3.37.1'
 def kotlin_reflect_version = '1.8.20'
-def hawking_version = '0.1.7'
+def hawking_version = '0.1.9'
 def postgres_kt_version = '0.9.3'
 
 // TEST


### PR DESCRIPTION
For this:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/42c3d6fc-aa84-4739-a116-89425d6c2cd9" />

Before (because parser only reads the 'tomorrow' part, somehow):
<img width="392" alt="image" src="https://github.com/user-attachments/assets/b6b89ff8-d9b3-4b2c-8c8b-ff0987398604" />

After:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/47752246-4646-4020-b8b1-1c8568e28e6e" />
