### PR TITLE
Add /pklstats extension with gamescreated type, for now

### DIFF
--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -16,10 +16,7 @@ import org.jdbi.v3.sqlobject.SqlObjectPlugin
 import org.jdbi.v3.sqlobject.kotlin.KotlinSqlObjectPlugin
 import org.jdbi.v3.sqlobject.kotlin.onDemand
 import org.slf4j.LoggerFactory
-import uk.co.mutuallyassureddistraction.paketliga.dao.GameDao
-import uk.co.mutuallyassureddistraction.paketliga.dao.GuessDao
-import uk.co.mutuallyassureddistraction.paketliga.dao.PointDao
-import uk.co.mutuallyassureddistraction.paketliga.dao.WinDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.*
 import uk.co.mutuallyassureddistraction.paketliga.event.GameCreatedEvent
 import uk.co.mutuallyassureddistraction.paketliga.extensions.*
 import uk.co.mutuallyassureddistraction.paketliga.matching.*
@@ -60,6 +57,7 @@ suspend fun main(args: Array<String>) {
         val guessDao = jdbi.onDemand<GuessDao>()
         val pointDao = jdbi.onDemand<PointDao>()
         val winDao = jdbi.onDemand<WinDao>()
+        val statsDao = jdbi.onDemand<StatsDao>()
         logger.info("Init Services")
         // Validators
         val gameValidator = GameValidator()
@@ -78,6 +76,7 @@ suspend fun main(args: Array<String>) {
         val gameEndService = GameEndService(guessDao, gameDao, gameResultResolver, pointUpdaterService)
         val leaderboardService = LeaderboardService(pointDao)
         val voidGameService = VoidGameService(gameDao)
+        val statsService = StatsService(statsDao)
 
         logger.info("Creating Extensions")
         val createGameExtension = CreateGameExtension(gameUpsertService, gameTimeParserService, SERVER_ID)
@@ -94,6 +93,7 @@ suspend fun main(args: Array<String>) {
         val rulesExtension = RulesExtension(SERVER_ID)
         val creditsExtension = CreditsExtension(SERVER_ID)
         val releaseNotesExtension = ReleaseNotesExtension(SERVER_ID)
+        val statsExtension = StatsExtension(statsService, SERVER_ID)
 
         logger.info("Creating bot")
         val bot =
@@ -117,6 +117,7 @@ suspend fun main(args: Array<String>) {
                     add { rulesExtension }
                     add { creditsExtension }
                     add { releaseNotesExtension }
+                    add { statsExtension }
                 }
             }
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/StatsDao.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/StatsDao.kt
@@ -1,0 +1,26 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao
+
+import org.jdbi.v3.sqlobject.statement.SqlQuery
+import org.jdbi.v3.sqlobject.statement.SqlUpdate
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.GameCreated
+
+interface StatsDao {
+    @SqlQuery(
+        """
+        SELECT a.userId, COUNT(userId) as gameCount,
+            (
+                SELECT carrier mostCarrier
+                FROM Game g
+                WHERE g.userId = a.userId
+                GROUP BY carrier
+                ORDER BY COUNT(carrier) DESC
+                LIMIT 1
+            )
+        FROM Game a
+        GROUP BY a.userId
+        ORDER BY gameCount
+        DESC
+    """
+    )
+    fun getGameCreatedSortedByCountDesc(): List<GameCreated>
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Stats.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/entity/Stats.kt
@@ -1,0 +1,7 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao.entity
+
+data class GameCreated (
+    val userId: String,
+    val gameCount: Int,
+    val mostCarrier: String
+)

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/StatsExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/StatsExtension.kt
@@ -1,0 +1,84 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.MemberBehavior
+import dev.kord.rest.builder.message.EmbedBuilder
+import dev.kordex.core.commands.Arguments
+import dev.kordex.core.commands.converters.impl.optionalString
+import dev.kordex.core.extensions.Extension
+import dev.kordex.core.extensions.publicSlashCommand
+import dev.kordex.core.i18n.toKey
+import uk.co.mutuallyassureddistraction.paketliga.matching.StatsService
+
+class StatsExtension(
+    private val statsService: StatsService,
+    private val serverId: Snowflake
+) : Extension() {
+    override val name = "statsExtension"
+
+    override suspend fun setup() {
+        publicSlashCommand(::StatsArgs) {
+            name = "pklstats".toKey()
+            description = "View PaketLiga stats".toKey()
+
+            guild(serverId)
+
+            action {
+                val statsType = arguments.statsType
+                if(statsType.isNullOrEmpty() || statsType == "help") {
+                    respond {
+                        content =
+                            """
+                            Choose your stats type:
+                            * `gamescreated` -> Show ranks for most game created. Capitalism, baby
+                        """.trimIndent()
+                    }
+                } else {
+                    val kord = this@StatsExtension.kord
+                    when (statsType.lowercase()) {
+                        "gamescreated" -> {
+                            val gameCreated = statsService.findCreatedGames()
+
+                            val paginator = respondingPaginator {
+                                var counter = 1
+                                gameCreated.chunked(10).map { response ->
+                                    val pageFields = ArrayList<EmbedBuilder.Field>()
+                                    response.forEach {
+                                        val memberBehavior = MemberBehavior(serverId, Snowflake(it.userId), kord)
+                                        val field = EmbedBuilder.Field()
+                                        field.inline = true
+                                        field.name = "# $counter : ${memberBehavior.asMember().effectiveName}" +
+                                                " | ${it.gameCount} games created"
+                                        field.value = "Most used carrier : **${it.mostCarrier}**"
+                                        pageFields.add(field)
+                                        counter++
+                                    }
+
+                                    page {
+                                        title = "PaketLiga - Number of Games Created: "
+                                        fields = pageFields
+                                    }
+                                }
+                                timeoutSeconds = 20L
+                            }
+                            paginator.send()
+                        }
+                        else -> {
+                            respond {
+                                ephemeral
+                                content = "No stats of type $statsType found"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    inner class StatsArgs : Arguments() {
+        val statsType by optionalString {
+            name = "type".toKey()
+            description = "Stats type to return".toKey()
+        }
+    }
+}

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/StatsService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/StatsService.kt
@@ -1,0 +1,10 @@
+package uk.co.mutuallyassureddistraction.paketliga.matching
+
+import uk.co.mutuallyassureddistraction.paketliga.dao.StatsDao
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.GameCreated
+
+class StatsService(private val statsDao: StatsDao) {
+    fun findCreatedGames(): List<GameCreated> {
+        return statsDao.getGameCreatedSortedByCountDesc()
+    }
+}

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/StatsDaoTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/dao/StatsDaoTest.kt
@@ -1,0 +1,54 @@
+package uk.co.mutuallyassureddistraction.paketliga.dao
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Game
+import uk.co.mutuallyassureddistraction.paketliga.dao.entity.GameCreated
+import java.time.ZonedDateTime
+import kotlin.test.assertEquals
+
+class StatsDaoTest {
+    private lateinit var target: StatsDao
+    private lateinit var gameDao: GameDao
+    private lateinit var testWrapper: DaoTestWrapper
+
+    @BeforeEach
+    fun setUp() {
+        testWrapper = initTests()
+        target = testWrapper.buildDao(StatsDao::class.java)
+        gameDao = testWrapper.buildDao(GameDao::class.java)
+        createGame()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        testWrapper.stopContainers()
+    }
+
+    @DisplayName("getGameCreatedSortedByCountDesc() will successfully return userId and count of game created")
+    @Test
+    fun canSuccessfullyGetGameCreatedSortedByCountDesc() {
+        val searchedStats: List<GameCreated> = target.getGameCreatedSortedByCountDesc()
+        assertEquals(searchedStats.first().userId, "Z")
+        assertEquals(searchedStats.first().gameCount, 1)
+        assertEquals(searchedStats.first().mostCarrier, "N/A")
+    }
+
+    private fun createGame() {
+        val game =
+            Game(
+                gameId = 1,
+                gameName = "A random game name for test",
+                windowStart = ZonedDateTime.parse("2023-04-07T09:00:00.000Z[Europe/London]"),
+                windowClose = ZonedDateTime.parse("2023-04-07T17:00:00.000Z[Europe/London]"),
+                guessesClose = ZonedDateTime.parse("2023-04-07T12:00:00.000Z[Europe/London]"),
+                deliveryTime = null,
+                userId = "Z",
+                carrier = "N/A",
+                gameActive = true,
+            )
+        gameDao.createGame(game)
+    }
+}


### PR DESCRIPTION
Added `/pklstats` command with optional string as a type. We're not using enum for now.

Empty string or "help":
<img width="445" alt="image" src="https://github.com/user-attachments/assets/62ba5fc4-c20d-4000-8f72-f64c8266be35" />

with "gamescreated":
<img width="467" alt="image" src="https://github.com/user-attachments/assets/b15b9e87-9254-4dc6-b437-857e1db8cdd6" />
