### PR TITLE
Sort leaderboard based on wins-played ratio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ outTmp/
 /kotlin-native/dist
 kotlin-ide/
 .idea
+/data/

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardService.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardService.kt
@@ -10,7 +10,7 @@ class LeaderboardService(private val pointDao: PointDao) {
     fun getLeaderboard(userId: String?, limit: Int?): List<Point> {
         try {
             if (userId == null) {
-                return pointDao.getPointsSortedByTotalPointsDesc(limit)
+                return sortByWinsAndPlayedRatio(pointDao.getPointsSortedByTotalPointsDesc(limit))
             }
 
             val userPoint = pointDao.getPointByUserId(userId)
@@ -21,5 +21,22 @@ class LeaderboardService(private val pointDao: PointDao) {
         }
 
         return arrayListOf()
+    }
+
+    private fun sortByWinsAndPlayedRatio(points: List<Point>): List<Point> {
+        val comparator = Comparator { p1: Point, p2: Point ->
+            if (p1.totalPoint.equals(p2.totalPoint)) {
+                val p1Ratio = p1.won.toBigDecimal().divide(p1.played.toBigDecimal())
+                val p2Ratio = p2.won.toBigDecimal().divide(p2.played.toBigDecimal())
+
+                return@Comparator p2Ratio.compareTo(p1Ratio)
+            }
+
+            return@Comparator p2.totalPoint.compareTo(p1.totalPoint)
+        }
+
+        val copy = arrayListOf<Point>().apply { addAll(points) }
+        copy.sortWith(comparator)
+        return copy
     }
 }

--- a/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardServiceTest.kt
+++ b/src/test/kotlin/uk/co/mutuallyassureddistraction/paketliga/matching/LeaderboardServiceTest.kt
@@ -3,7 +3,6 @@ package uk.co.mutuallyassureddistraction.paketliga.matching
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import uk.co.mutuallyassureddistraction.paketliga.dao.PointDao
@@ -11,22 +10,15 @@ import uk.co.mutuallyassureddistraction.paketliga.dao.entity.Point
 
 class LeaderboardServiceTest {
     private lateinit var target: LeaderboardService
-
-    @BeforeEach
-    fun setUp() {
-        val pointDao = mockk<PointDao>()
-        Point(1, "Z", 1, 1, 1, 0, 0, 1F)
-
-        every { pointDao.getPointByUserId(any()) } returns Point(2, "Y", 1, 1, 1, 0, 0, 3F)
-        every { pointDao.getPointsSortedByTotalPointsDesc(null) } returns
-            arrayListOf(Point(2, "Y", 1, 1, 1, 0, 0, 3F), Point(1, "Z", 1, 1, 1, 0, 0, 1F))
-
-        target = LeaderboardService(pointDao)
-    }
+    private lateinit var pointDao: PointDao
 
     @DisplayName("getLeaderboard() with userid will return one point")
     @Test
     fun whenGetWithUserIdReturnOnePoint() {
+        pointDao = mockk<PointDao>()
+        every { pointDao.getPointByUserId(any()) } returns Point(2, "Y", 1, 1, 1, 0, 0, 3F)
+        target = LeaderboardService(pointDao)
+
         val points = target.getLeaderboard("Y", null)
         assertEquals(points.size, 1)
         assertEquals(points[0].userId, "Y")
@@ -35,9 +27,35 @@ class LeaderboardServiceTest {
     @DisplayName("getLeaderboard() with null userid will return all points")
     @Test
     fun whenGetWithoutUserIdReturnAllPoints() {
+        pointDao = mockk<PointDao>()
+        every { pointDao.getPointsSortedByTotalPointsDesc(null) } returns
+            arrayListOf(Point(2, "Y", 1, 1, 1, 0, 0, 3F), Point(1, "Z", 1, 1, 1, 0, 0, 1F))
+        target = LeaderboardService(pointDao)
+
         val points = target.getLeaderboard(null, null)
         assertEquals(points.size, 2)
         assertEquals(points[0].userId, "Y")
         assertEquals(points[1].userId, "Z")
+    }
+
+    @DisplayName("getLeaderboard() with same points will be sorted based on wins/played ratio ")
+    @Test
+    fun whenGetWithSamePointsThenSortByWinsAndPlayedRatio() {
+        pointDao = mockk<PointDao>()
+        every { pointDao.getPointsSortedByTotalPointsDesc(null) } returns
+            arrayListOf(
+                Point(4, "W", 5, 3, 0, 0, 0, 3F),
+                Point(3, "X", 8, 3, 0, 0, 0, 3F),
+                Point(2, "Y", 3, 3, 0, 0, 0, 3F),
+                Point(1, "Z", 1, 1, 1, 0, 0, 1F),
+            )
+        target = LeaderboardService(pointDao)
+
+        val points = target.getLeaderboard(null, null)
+        assertEquals(points.size, 3)
+        assertEquals(points[0].userId, "Y")
+        assertEquals(points[1].userId, "W")
+        assertEquals(points[2].userId, "X")
+        assertEquals(points[3].userId, "Z")
     }
 }


### PR DESCRIPTION
e.g. there are 4 players:
- W: won 3, played 5, total points 3
- X: won 3, played 8, total points 3
- Y: won 3, played 3, total points 3
- Z: won 1, played 1, total points 3

The order would be:
1. Y
2. W
3. X
4. Z